### PR TITLE
Support EIP-8004

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 scanner = { path = "scanner", version = "0.1" }
 x402 = { path = "x402", version = "0.1" }
+eip8004 = { git = "https://github.com/zpaynow/8004" }
 alloy = "1.0"
 anyhow = "1.0"
 async-trait = "0.1"

--- a/x402/Cargo.toml
+++ b/x402/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+eip8004.workspace = true
 alloy.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true

--- a/x402/src/client.rs
+++ b/x402/src/client.rs
@@ -130,7 +130,7 @@ impl ClientFacilitator {
                 payload: SchemePayload {
                     signature,
                     authorization,
-                    feedback_index: feedback_index,
+                    feedback_index,
                 },
             })
         } else {

--- a/x402/src/client.rs
+++ b/x402/src/client.rs
@@ -97,11 +97,12 @@ impl ClientFacilitator {
     pub fn build<'a>(
         &self,
         prs: &'a [PaymentRequirements],
+        feedback_index: Option<u64>,
     ) -> Result<(PaymentPayload, &'a PaymentRequirements)> {
         for pr in prs.iter() {
             let identity = format!("{}-{}", pr.scheme, pr.network);
             if self.infos.contains_key(&identity) {
-                let payload = self.build_with_scheme(pr)?;
+                let payload = self.build_with_scheme(pr, feedback_index)?;
                 return Ok((payload, pr));
             }
         }
@@ -110,7 +111,11 @@ impl ClientFacilitator {
     }
 
     /// Build the payment payload by a paymentRequirements
-    pub fn build_with_scheme(&self, pr: &PaymentRequirements) -> Result<PaymentPayload> {
+    pub fn build_with_scheme(
+        &self,
+        pr: &PaymentRequirements,
+        feedback_index: Option<u64>,
+    ) -> Result<PaymentPayload> {
         let identity = format!("{}-{}", pr.scheme, pr.network);
 
         if let Some(info) = self.infos.get(&identity) {
@@ -125,6 +130,7 @@ impl ClientFacilitator {
                 payload: SchemePayload {
                     signature,
                     authorization,
+                    feedback_index: feedback_index,
                 },
             })
         } else {

--- a/x402/src/facilitator.rs
+++ b/x402/src/facilitator.rs
@@ -76,6 +76,7 @@ impl Facilitator {
                 transaction: "".to_owned(),
                 network: req.payment_payload.network.clone(),
                 payer: req.payment_payload.payload.authorization.from.clone(),
+                feedback_auth: None,
             }
         }
     }

--- a/x402/src/lib.rs
+++ b/x402/src/lib.rs
@@ -7,6 +7,7 @@ pub mod facilitator;
 pub use facilitator::Facilitator;
 
 use async_trait::async_trait;
+use eip8004::FeedbackAuth;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -75,6 +76,10 @@ pub struct SchemePayload {
     pub signature: String,
     /// EIP-3009 authorization parameters
     pub authorization: Authorization,
+    /// The index in client feedback for 8004 Reputation,
+    /// If has this field, and service has register agent info,
+    /// The `SettlementResponse` will has `feedback_auth` field.
+    pub feedback_index: Option<u64>,
 }
 
 /// EIP-3009 authorization parameters
@@ -126,6 +131,7 @@ impl VerifyResponse {
             transaction: tx.to_owned(),
             network: network.to_owned(),
             payer: self.payer,
+            feedback_auth: None,
         }
     }
 }
@@ -144,6 +150,8 @@ pub struct SettlementResponse {
     pub network: String,
     /// Address of the payer's wallet
     pub payer: String,
+    /// The feedback authorized signature for 8004 Reputation
+    pub feedback_auth: Option<FeedbackAuth>,
 }
 
 /// List supported payment schemes.
@@ -338,6 +346,7 @@ impl Error {
             transaction: "".to_owned(),
             network: req.network.clone(),
             payer: req.payload.authorization.from.clone(),
+            feedback_auth: None,
         }
     }
 }

--- a/x402/src/lib.rs
+++ b/x402/src/lib.rs
@@ -1,5 +1,5 @@
 mod scheme;
-pub use scheme::evm::EvmScheme;
+pub use scheme::evm::{Evm8004Registry, EvmAsset, EvmScheme};
 pub use scheme::sol::SolScheme;
 
 pub mod client;

--- a/x402/src/scheme/evm.rs
+++ b/x402/src/scheme/evm.rs
@@ -3,7 +3,7 @@ use crate::{
     VerifyRequest, VerifyResponse,
 };
 use alloy::{
-    primitives::{Address, B256, U256},
+    primitives::{Address, B256, Bytes, U256},
     providers::{Provider, ProviderBuilder},
     signers::{Signature, SignerSync, local::PrivateKeySigner},
     sol,
@@ -12,7 +12,7 @@ use alloy::{
 };
 use anyhow::Result;
 use async_trait::async_trait;
-use eip8004::FeedbackAuth;
+use eip8004::{FeedbackAuth, FeedbackOnchainAuth};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -61,6 +61,7 @@ impl TransferWithAuthorization {
     }
 }
 
+/// EIP-3009 based assets/tokens
 pub struct EvmAsset {
     name: String,
     version: String,
@@ -69,21 +70,58 @@ pub struct EvmAsset {
     extra: Value,
 }
 
+/// EIP-8004 agent registry infomation
+#[derive(Clone, Debug)]
+pub struct Evm8004Registry {
+    pub agent_id: i64,
+    pub identity: String,
+}
+
+struct InnerEvm8004Registry {
+    pub agent_id: U256,
+    pub identity_registry: Address,
+}
+
+/// Evm-based scheme
 pub struct EvmScheme {
+    chain_id: u64,
     scheme: String,
     network: String,
     rpc: Url,
     signer: PrivateKeySigner,
     assets: HashMap<Address, EvmAsset>,
+    agent: Option<InnerEvm8004Registry>,
 }
 
 impl EvmScheme {
-    pub fn new(url: &str, network: &str, signer: &str) -> Result<Self> {
-        let rpc = url.parse()?;
+    /// Build the evm scheme with EIP-8004 agent
+    pub async fn new(
+        url: &str,
+        network: &str,
+        signer: &str,
+        agent: Option<Evm8004Registry>,
+    ) -> Result<Self> {
+        let rpc: Url = url.parse()?;
         let signer = signer.parse()?;
+
+        let provider = ProviderBuilder::new().connect_http(rpc.clone());
+        let chain_id = provider.get_chain_id().await?;
+
+        let agent = if let Some(agent) = agent {
+            let identity_registry: Address = agent.identity.parse()?;
+            Some(InnerEvm8004Registry {
+                agent_id: U256::from(agent.agent_id),
+                identity_registry,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
+            chain_id,
             rpc,
             signer,
+            agent,
             scheme: SCHEME.to_owned(),
             network: network.to_owned(),
             assets: HashMap::new(),
@@ -106,9 +144,6 @@ impl EvmScheme {
         // Create provider and contract instance
         let provider = ProviderBuilder::new().connect_http(self.rpc.clone());
 
-        // Get chain ID for EIP-712 domain
-        let chain_id = provider.get_chain_id().await?;
-
         // Verify the contract has the required EIP-3009 functions by calling view functions
         let contract = Eip3009Token::new(token_address, &provider);
         let decimal = contract.decimals().call().await?;
@@ -124,7 +159,7 @@ impl EvmScheme {
         let domain = create_eip712_domain(
             name.to_string(),
             version.to_string(),
-            chain_id,
+            self.chain_id,
             token_address,
         );
 
@@ -326,20 +361,29 @@ impl EvmScheme {
             .await
             .map_err(|_| Error::InvalidTransactionState)?;
 
-        let feedback_auth = if let Some(index) = req.payment_payload.payload.feedback_index {
-            // TODO
-            Some(FeedbackAuth {
-                agent_id: 0,
-                client_address: req.payment_payload.payload.authorization.from.clone(),
-                index_limit: index,
-                expiry: 0,
-                chain_id: 0,
-                identity_registry: "".to_owned(),
-                signer_address: "".to_owned(),
-                signature: Some("".to_owned()),
-            })
-        } else {
-            None
+        let feedback_auth = match (&self.agent, req.payment_payload.payload.feedback_index) {
+            (Some(agent), Some(index)) => {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map_err(|_| Error::UnexpectedVerifyError)?
+                    .as_secs();
+                let expiry = now + 86400; // default is 1 Day
+
+                let mut feedback = FeedbackOnchainAuth {
+                    agentId: agent.agent_id,
+                    identityRegistry: agent.identity_registry,
+                    clientAddress: from,
+                    indexLimit: index,
+                    expiry: U256::from(expiry),
+                    chainId: U256::from(self.chain_id),
+                    signerAddress: self.signer.address(),
+                    signature: Bytes::default(),
+                };
+                let _ = feedback.sign(&self.signer).await;
+
+                Some(feedback.to_feedback_auth())
+            }
+            _ => None,
         };
 
         // Return the transaction hash


### PR DESCRIPTION
refs: #12 , 8004 SDK: https://github.com/zpaynow/8004

Keys:
- ~~auto-register agent when config in .env (default use https://domain/x402/agent, but is config the supported ipfs provider, will use ipfs)~~
- ~~avoid-re-register~~
- when payment payload has `feedback_index`, will auto add `feedback_auth` in settle response

updated:
do not do register in the service, avoid too many params. just register in other website and then config it here.